### PR TITLE
 Emit read for DLL's loaded before we get loaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 *.gch
 *.pch
 
+# Dependencies
+*.d
+
 # Libraries
 *.lib
 *.a
@@ -32,6 +35,7 @@
 *.dSYM/
 
 .stack-work/
+.vscode/
 
 *~
 *#

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ ifeq ($(OS), Windows_NT)
 
 PLAT=win
 EXE=.exe
-ROOT64=$(LOCALAPPDATA)\Programs\stack\x86_64-windows\ghc-8.0.2\mingw
-ROOT32=$(LOCALAPPDATA)\Programs\stack\i386-windows\ghc-8.0.2\mingw
+ROOT64=$(LOCALAPPDATA)\Programs\stack\x86_64-windows\ghc-8.6.3\mingw
+ROOT32=$(LOCALAPPDATA)\Programs\stack\i386-windows\ghc-8.6.3\mingw
 CC=$(ROOT64)\bin\gcc
 CC32=$(ROOT32)\bin\gcc
 CPPFLAGS=-D_WIN32_WINNT=0x600 -isystem$(ROOT64)\x86_64-w64-mingw32\include\ddk

--- a/src/win/fsatracedll.c
+++ b/src/win/fsatracedll.c
@@ -1,8 +1,11 @@
 #include <windows.h>
+#include <psapi.h>
+#include <stdio.h>
 #include "../emit.h"
 #include "patch.h"
 #include "dbg.h"
 #include "hooks.h"
+#include "utf8.h"
 
 static void * resolve(const char * name) {
 	void * ret;
@@ -19,6 +22,24 @@ INT APIENTRY DllMain(HMODULE hDLL, DWORD Reason, LPVOID Reserved) {
 	switch (Reason) {
 	case DLL_PROCESS_ATTACH:
 		emitInit();
+		{
+			// DLLs that were loaded before we got hooked, so mark them as a read dependency
+			DWORD cb = 0;
+			wchar_t winBuf[PATH_MAX];
+			char utfBuf[PATH_MAX];
+			HANDLE hProcess = GetCurrentProcess();
+			if (EnumProcessModules(hProcess, NULL, 0, &cb)) {
+				HMODULE* modules = malloc(cb);
+				if (EnumProcessModules(hProcess, modules, cb, &cb)) {
+					for (int i = 0; i < cb / sizeof(HMODULE); i++) {
+						DWORD res = GetModuleFileNameExW(hProcess, modules[i], winBuf, PATH_MAX);
+						if (res != 0)
+							emitOp('r', utf8PathFromWide(utfBuf, winBuf, res), 0);
+					}
+				}
+				free(modules);
+			}
+		}
 		patchInit();
 		hooksInit(resolve);
 		break;


### PR DESCRIPTION
On Windows the executable and other dlls get loaded before we do, so we don't spot any reads they do. To paper over that we list all dlls and the exe and add read events for them.

Fixes #19 