### PR TITLE
Revise the test suite

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -2,4 +2,4 @@
 :set -Wall
 :set -itest
 :load test/Test.hs test/DumpArgs.hs
-:def test \x -> return ":!stack exec make htest"
+:def test \_ -> return ":!stack exec make htest"

--- a/.ghci
+++ b/.ghci
@@ -1,4 +1,3 @@
 :set -Wunused-binds -Wunused-imports -Worphans
-:cd test
-:load Test.hs DumpArgs.hs
-:def test \x -> return ":!stack test"
+:load test/Test.hs test/DumpArgs.hs
+:def test \x -> return ":!stack exec make htest"

--- a/.ghci
+++ b/.ghci
@@ -1,3 +1,4 @@
+:set -Wunused-binds -Wunused-imports -Worphans
 :cd test
 :load Test.hs DumpArgs.hs Harness.hs
 :def test \x -> return ":!stack test"

--- a/.ghci
+++ b/.ghci
@@ -1,4 +1,4 @@
 :set -Wunused-binds -Wunused-imports -Worphans
 :cd test
-:load Test.hs DumpArgs.hs Harness.hs
+:load Test.hs DumpArgs.hs
 :def test \x -> return ":!stack test"

--- a/.ghci
+++ b/.ghci
@@ -1,3 +1,4 @@
 :set -Wunused-binds -Wunused-imports -Worphans
+:set -itest
 :load test/Test.hs test/DumpArgs.hs
 :def test \x -> return ":!stack exec make htest"

--- a/.ghci
+++ b/.ghci
@@ -1,0 +1,3 @@
+:cd test
+:load Test.hs DumpArgs.hs Harness.hs
+:def test \x -> return ":!stack test"

--- a/.ghci
+++ b/.ghci
@@ -1,4 +1,5 @@
 :set -Wunused-binds -Wunused-imports -Worphans
+:set -Wall
 :set -itest
 :load test/Test.hs test/DumpArgs.hs
 :def test \x -> return ":!stack exec make htest"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,5 @@ before_install:
 - cp stack-*/stack ~/.local/bin
 
 script:
-- make
-- cd test
 - stack setup
-- stack test
-
+- make htest

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ ifeq ($(OS), Windows_NT)
 
 PLAT=win
 EXE=.exe
-ROOT64=$(LOCALAPPDATA)\Programs\stack\x86_64-windows\ghc-8.6.3\mingw
-ROOT32=$(LOCALAPPDATA)\Programs\stack\i386-windows\ghc-8.6.3\mingw
+ROOT64=$(LOCALAPPDATA)\Programs\stack\x86_64-windows\ghc-8.6.5\mingw
+ROOT32=$(LOCALAPPDATA)\Programs\stack\i386-windows\ghc-8.6.5\mingw
 CC=$(ROOT64)\bin\gcc
 CC32=$(ROOT32)\bin\gcc
 CPPFLAGS=-D_WIN32_WINNT=0x600 -isystem$(ROOT64)\x86_64-w64-mingw32\include\ddk

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,13 @@ CFLAGS+= -g -std=c99 -Wall -O2 -fomit-frame-pointer -fno-stack-protector -MMD
 
 SRCS=src/fsatrace.c src/$(PLAT)/proc.c src/$(PLAT)/shm.c $(OSSRCS)
 
-all: fsatrace$(EXE) lib
+all: fsatrace$(EXE) lib fsatest$(EXE) fsatest32$(EXE)
 
 fsatrace$(EXE): $(patsubst %.c,%.o,$(SRCS))
 	$(CC) $(LDFLAGS) $(LDOBJS) $^ $(LDLIBS) -o $@
+
+fsatest$(EXE): src/fsatest.o
+	$(CC) $^ -o $@
 
 dumpargs$(EXE): dumpargs.o
 	$(CC) $(LDFLAGS) $^ $(LDLIBS) -o $@

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,8 @@ install:
 - cinst make
 - curl -ostack.zip -L --insecure http://www.stackage.org/stack/windows-x86_64
 - 7z x stack.zip stack.exe
-- stack setup --resolver ghc-8.6.3 --arch=x86_64 > nul
-- stack setup --resolver ghc-8.6.3 --arch=i386 > nul
+- stack setup --resolver ghc-8.6.5 --arch=x86_64 > nul
+- stack setup --resolver ghc-8.6.5 --arch=i386 > nul
 - set PATH=%PATH%;%CD%
 
 build: off

--- a/src/fsatest.c
+++ b/src/fsatest.c
@@ -15,16 +15,17 @@
 
 void unescape(char* s)
 {
-    for (int i = 0; s[i]; i++) {
-        if (s[i] != '#') continue;
-
-        if (s[i+1] != '#') {
-            s[i] = ' ';
-        } else {
-            memmove(&s[i], &s[i+1], strlen(&s[i+1]));
-            i++;
-        }
+    // w = write index, r = read index
+    int w = 0;
+    for (int r = 0; s[r]; r++) {
+        if (s[r] != '#')
+            s[w++] = s[r];
+        else if (s[r+1] != '#')
+            s[w++] = ' ';
+        else
+            s[w++] = s[++r];
     }
+    s[w] = 0;
 }
 
 int main(int argc, const char* argv[])

--- a/src/fsatest.c
+++ b/src/fsatest.c
@@ -39,7 +39,7 @@ void exec(char* s)
         if (args[i] == NULL)
             break;
     }
-    execv(cmd, args);
+    spawnv(P_WAIT, cmd, args);
 }
 
 int main(int argc, const char* argv[])

--- a/src/fsatest.c
+++ b/src/fsatest.c
@@ -4,6 +4,7 @@
    rfile -- file to read
    wfile -- file to write
    e[command] -- command to execute
+   sN -- sleep for N seconds
    f -- raise a failure
 */
 
@@ -46,10 +47,12 @@ int main(int argc, const char* argv[])
 {
     int trace = 0;
     int exitCode = 0;
+
     for (int i = 1; i < argc; i++) {
         const char* s = argv[i];
         FILE* fp;
         char* cmdline;
+        int seconds;
 
         switch (s[0]) {
             case 'r':
@@ -65,6 +68,12 @@ int main(int argc, const char* argv[])
                 fp = fopen(&s[1], "w");
                 fputs("Written by fsatest harness\n", fp);
                 fclose(fp);
+                break;
+
+            case 's':
+                seconds = atoi(&s[i]);
+                if (trace) printf("Sleeping for: %is\n", seconds);
+                sleep(seconds);
                 break;
 
             case 'f':

--- a/src/fsatest.c
+++ b/src/fsatest.c
@@ -13,9 +13,6 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#ifndef _WIN32_WINNT
-#include <spawn.h>
-#endif
 
 void unescape(char* s)
 {
@@ -32,18 +29,30 @@ void unescape(char* s)
     s[w] = 0;
 }
 
+
 void exec(char* s)
 {
-    char* cmd;
+#ifndef _WIN32_WINNT
+	int child;
+    int rc;
+#endif
+
     char* args[1000];
-    cmd = strtok (s, " ");
-    args[0] = cmd;
+    args[0] = strtok (s, " ");
     for (int i = 1; i < 1000; i++) {
         args[i] = strtok(NULL, " ");
         if (args[i] == NULL)
             break;
     }
-    spawnv(P_WAIT, cmd, args);
+
+#ifdef _WIN32_WINNT
+    spawnv(P_WAIT, args[0], args);
+#else
+	child = fork();
+    if (child == 0)
+		execvp(args[0], args);
+    waitpid(child, &rc, 0);
+#endif
 }
 
 int main(int argc, const char* argv[])

--- a/src/fsatest.c
+++ b/src/fsatest.c
@@ -1,0 +1,74 @@
+
+
+/* Take a command line of options to perform
+   rfile -- file to read
+   wfile -- file to write
+   e[command] -- command to execute
+   f -- raise a failure
+*/
+
+#include <stdio.h>
+#include <string.h>
+#include <malloc.h>
+#include <stdlib.h>
+
+
+void unescape(char* s)
+{
+    for (int i = 0; s[i]; i++) {
+        if (s[i] != '#') continue;
+
+        if (s[i+1] != '#') {
+            s[i] = ' ';
+        } else {
+            memmove(&s[i], &s[i+1], strlen(&s[i+1]));
+            i++;
+        }
+    }
+}
+
+int main(int argc, const char* argv[])
+{
+    int trace = 0;
+    int exitCode = 0;
+    for (int i = 1; i < argc; i++) {
+        const char* s = argv[i];
+        FILE* fp;
+        char* cmdline;
+
+        switch (s[0]) {
+            case 'r':
+                if (trace) printf("Reading from: %s\n", &s[1]);
+                fp = fopen(&s[1], "r");
+                while(fgetc(fp) != EOF)
+                    ; // nothing
+                fclose(fp);
+                break;
+
+            case 'w':
+                if (trace) printf("Writing to: %s\n", &s[1]);
+                fp = fopen(&s[1], "w");
+                fputs("Written by fsatest harness\n", fp);
+                fclose(fp);
+                break;
+
+            case 'f':
+                if (trace) printf("Will return a failing exit code\n");
+                exitCode = 1;
+                break;
+
+            case 'e':
+                cmdline = strdup(&s[1]);
+                unescape(cmdline);
+                if (trace) printf("Running command: %s\n", cmdline);
+                system(cmdline);
+                free(cmdline);
+                break;
+
+            default:
+                printf("FAILED: Could not interpret command line: %s\n", s);
+                return 1;
+        }
+    }
+    return exitCode;
+}

--- a/src/fsatest.c
+++ b/src/fsatest.c
@@ -9,7 +9,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <malloc.h>
 #include <stdlib.h>
 #include <unistd.h>
 

--- a/src/fsatest.c
+++ b/src/fsatest.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <malloc.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 
 void unescape(char* s)
@@ -26,6 +27,20 @@ void unescape(char* s)
             s[w++] = s[++r];
     }
     s[w] = 0;
+}
+
+void exec(char* s)
+{
+    char* cmd;
+    char* args[1000];
+    cmd = strtok (s, " ");
+    args[0] = cmd;
+    for (int i = 1; i < 1000; i++) {
+        args[i] = strtok(NULL, " ");
+        if (args[i] == NULL)
+            break;
+    }
+    execv(cmd, args);
 }
 
 int main(int argc, const char* argv[])
@@ -62,7 +77,7 @@ int main(int argc, const char* argv[])
                 cmdline = strdup(&s[1]);
                 unescape(cmdline);
                 if (trace) printf("Running command: %s\n", cmdline);
-                system(cmdline);
+                exec(cmdline);
                 free(cmdline);
                 break;
 

--- a/src/fsatest.c
+++ b/src/fsatest.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <process.h>
 #include <unistd.h>
 
 

--- a/src/fsatest.c
+++ b/src/fsatest.c
@@ -11,9 +11,11 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <process.h>
 #include <unistd.h>
 
+#ifndef _WIN32_WINNT
+#include <spawn.h>
+#endif
 
 void unescape(char* s)
 {

--- a/test/DumpArgs.hs
+++ b/test/DumpArgs.hs
@@ -1,6 +1,6 @@
 
 -- | Dump the arguments returned by Haskell
-module Main(main) where
+module DumpArgs(main) where
 
 import System.Environment
 

--- a/test/DumpArgs.hs
+++ b/test/DumpArgs.hs
@@ -1,6 +1,8 @@
-module Main where
 
-import           System.Environment
+-- | Dump the arguments returned by Haskell
+module Main(main) where
+
+import System.Environment
 
 main :: IO ()
 main = getArgs >>= print

--- a/test/Parse.hs
+++ b/test/Parse.hs
@@ -1,0 +1,54 @@
+
+-- | A test of the FSATrace program
+module Parse(
+    Access(..), parse, parseClDeps, parseDeps
+) where
+
+import           Utils
+import           Data.Maybe
+
+
+data Access = R Path
+            | W Path
+            | D Path
+            | Q Path
+            | T Path
+            | M Path Path
+            | RR Path
+            | RW Path
+            | RD Path
+            | RQ Path
+            | RT Path
+            | RM Path Path
+            deriving (Show, Eq, Ord)
+
+parse :: String -> [Access]
+parse = mapMaybe f . lines
+    where f ('w':'|':xs) = Just $ W $ Path xs
+          f ('r':'|':xs) = Just $ R $ Path xs
+          f ('d':'|':xs) = Just $ D $ Path xs
+          f ('q':'|':xs) = Just $ Q $ Path xs
+          f ('t':'|':xs) = Just $ T $ Path xs
+          f ('m':'|':xs) | (xs','|':ys) <- break (== '|') xs = Just $ M (Path xs') (Path ys)
+          f ('W':'|':xs) = Just $ RW $ Path xs
+          f ('R':'|':xs) = Just $ RR $ Path xs
+          f ('D':'|':xs) = Just $ RD $ Path xs
+          f ('Q':'|':xs) = Just $ RQ $ Path xs
+          f ('T':'|':xs) = Just $ RT $ Path xs
+          f ('M':'|':xs) | (xs','|':ys) <- break (== '|') xs = Just $ RM (Path xs') (Path ys)
+          f _ = Nothing
+
+
+parseDeps :: Maybe String -> [FilePath]
+parseDeps = filter (/= " ") . map unhack . words . hack . drop 1 . dropWhile (/= ':') . fromMaybe ""
+  where hack ('\\':' ':xs) = '^':hack xs
+        hack ('\\':'\n':xs) = ' ':hack xs
+        hack (x:xs) = x:hack xs
+        hack [] = []
+        unhack = map (\x -> if x == '^' then ' ' else x)
+
+parseClDeps :: String -> [FilePath]
+parseClDeps = mapMaybe parseLine . lines
+  where parseLine ('N':xs) = Just $ dropWhile (== ' ') $ skip ':' $ skip ':' xs
+        parseLine _ = Nothing
+        skip c = drop 1 . dropWhile (/= c)

--- a/test/Parse.hs
+++ b/test/Parse.hs
@@ -1,41 +1,42 @@
+{-# LANGUAGE DeriveFunctor #-}
 
 -- | A test of the FSATrace program
 module Parse(
     Access(..), parseFSATrace, parseClDeps, parseMakefileDeps
 ) where
 
-import           Utils
 import           Data.Maybe
 
 
-data Access = R Path
-            | W Path
-            | D Path
-            | Q Path
-            | T Path
-            | M Path Path
-            | RR Path
-            | RW Path
-            | RD Path
-            | RQ Path
-            | RT Path
-            | RM Path Path
-            deriving (Show, Eq, Ord)
+data Access a
+    = R a
+    | W a
+    | D a
+    | Q a
+    | T a
+    | M a a
+    | RR a
+    | RW a
+    | RD a
+    | RQ a
+    | RT a
+    | RM a a
+      deriving (Show, Eq, Ord, Functor)
 
-parseFSATrace :: String -> [Access]
+parseFSATrace :: String -> [Access FilePath]
 parseFSATrace = mapMaybe f . lines
-    where f ('w':'|':xs) = Just $ W $ Path xs
-          f ('r':'|':xs) = Just $ R $ Path xs
-          f ('d':'|':xs) = Just $ D $ Path xs
-          f ('q':'|':xs) = Just $ Q $ Path xs
-          f ('t':'|':xs) = Just $ T $ Path xs
-          f ('m':'|':xs) | (xs','|':ys) <- break (== '|') xs = Just $ M (Path xs') (Path ys)
-          f ('W':'|':xs) = Just $ RW $ Path xs
-          f ('R':'|':xs) = Just $ RR $ Path xs
-          f ('D':'|':xs) = Just $ RD $ Path xs
-          f ('Q':'|':xs) = Just $ RQ $ Path xs
-          f ('T':'|':xs) = Just $ RT $ Path xs
-          f ('M':'|':xs) | (xs','|':ys) <- break (== '|') xs = Just $ RM (Path xs') (Path ys)
+    where f ('w':'|':xs) = Just $ W xs
+          f ('r':'|':xs) = Just $ R xs
+          f ('d':'|':xs) = Just $ D xs
+          f ('q':'|':xs) = Just $ Q xs
+          f ('t':'|':xs) = Just $ T xs
+          f ('m':'|':xs) | (xs','|':ys) <- break (== '|') xs = Just $ M xs' ys
+          f ('W':'|':xs) = Just $ RW xs
+          f ('R':'|':xs) = Just $ RR xs
+          f ('D':'|':xs) = Just $ RD xs
+          f ('Q':'|':xs) = Just $ RQ xs
+          f ('T':'|':xs) = Just $ RT xs
+          f ('M':'|':xs) | (xs','|':ys) <- break (== '|') xs = Just $ RM xs' ys
           f _ = Nothing
 
 

--- a/test/Parse.hs
+++ b/test/Parse.hs
@@ -1,7 +1,7 @@
 
 -- | A test of the FSATrace program
 module Parse(
-    Access(..), parse, parseClDeps, parseDeps
+    Access(..), parseFSATrace, parseClDeps, parseMakefileDeps
 ) where
 
 import           Utils
@@ -22,8 +22,8 @@ data Access = R Path
             | RM Path Path
             deriving (Show, Eq, Ord)
 
-parse :: String -> [Access]
-parse = mapMaybe f . lines
+parseFSATrace :: String -> [Access]
+parseFSATrace = mapMaybe f . lines
     where f ('w':'|':xs) = Just $ W $ Path xs
           f ('r':'|':xs) = Just $ R $ Path xs
           f ('d':'|':xs) = Just $ D $ Path xs
@@ -39,8 +39,8 @@ parse = mapMaybe f . lines
           f _ = Nothing
 
 
-parseDeps :: Maybe String -> [FilePath]
-parseDeps = filter (/= " ") . map unhack . words . hack . drop 1 . dropWhile (/= ':') . fromMaybe ""
+parseMakefileDeps :: Maybe String -> [FilePath]
+parseMakefileDeps = filter (/= " ") . map unhack . words . hack . drop 1 . dropWhile (/= ':') . fromMaybe ""
   where hack ('\\':' ':xs) = '^':hack xs
         hack ('\\':'\n':xs) = ' ':hack xs
         hack (x:xs) = x:hack xs

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -108,16 +108,15 @@ yields eargs eres = do
     assert ok
 
 data ShellMode = Unshelled | Shelled deriving (Show, Eq, Enum, Bounded)
-data TraceMode = Untraced | Traced deriving (Show, Eq, Enum, Bounded)
+data TraceMode = Traced deriving (Show, Eq, Enum, Bounded)
 data SpaceMode = Unspaced | Spaced deriving (Show, Eq, Enum, Bounded)
 
 
 command :: String -> [String] -> Reader Env [String]
 command flags args = do
   e <- ask
-  return $ cmd (shellMode e) (traceMode e)
+  return $ fsatrace flags ++ cmd (shellMode e) (traceMode e)
   where cmd :: ShellMode -> TraceMode -> [String]
-        cmd sm Traced = fsatrace flags ++ cmd sm Untraced
         cmd Unshelled _ = args
         cmd Shelled _ | isWindows = "cmd.exe" : "/C" : args
                       | otherwise = ["sh", "-c", unwords (map quoted args)]

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -2,10 +2,11 @@
 -- | A test of the FSATrace program
 module Test(main) where
 
+import           Utils
+
 import           Control.Monad
 import           Control.Monad.Trans.Reader
 import           Data.List.Extra
-import           Data.Char
 import           Data.Maybe
 import           System.Directory
 import           System.Exit
@@ -16,32 +17,6 @@ import           System.Process
 import           Test.QuickCheck
 import           Test.QuickCheck.Monadic
 --import           Debug.Trace
-
-data Env = Env
-    { shellMode :: ShellMode
-    , tmpDir :: FilePath
-    , pwdDir :: FilePath
-    }
-
-type Prop = Reader Env Property
-
-newtype Arg = Arg { unarg :: String } deriving (Show, Eq)
-
-instance Arbitrary Arg where
-  arbitrary = Arg <$> listOf1 validChars
-    where validChars = arbitrary `suchThat` (`notElem` "\0")
-
-newtype Path = Path { unpath :: FilePath }
-
-instance Eq Path where
-  (==) (Path a) (Path b) = equalFilePath a b
-
-instance Show Path where
-  show (Path p) = show p
-
-instance Ord Path where
-  compare (Path x) (Path y) = compare (cased x) (cased y)
-
 
 prop_args :: [Arg] -> Prop
 prop_args args = do
@@ -100,9 +75,6 @@ yields eargs res = do
       putStrLn $ "Expecting " ++ show res
       putStrLn $ "Got       " ++ show sr
     assert ok
-
-data ShellMode = Unshelled | Shelled deriving (Show, Eq, Enum, Bounded)
-data SpaceMode = Unspaced | Spaced deriving (Show, Eq, Enum, Bounded)
 
 
 command :: String -> [String] -> Reader Env [String]
@@ -179,52 +151,3 @@ main = do
             ]
             ++ [qc "cl" $ prop_cl clcsrc (rvalid ncldeps) | hascl]
             ++ [qc "echo" $ prop_echo emitc srcc | sm == Shelled]
-
-
-data Access = R Path
-            | W Path
-            | D Path
-            | Q Path
-            | T Path
-            | M Path Path
-            | RR Path
-            | RW Path
-            | RD Path
-            | RQ Path
-            | RT Path
-            | RM Path Path
-            deriving (Show, Eq, Ord)
-
-parse :: String -> [Access]
-parse = mapMaybe f . lines
-    where f ('w':'|':xs) = Just $ W $ Path xs
-          f ('r':'|':xs) = Just $ R $ Path xs
-          f ('d':'|':xs) = Just $ D $ Path xs
-          f ('q':'|':xs) = Just $ Q $ Path xs
-          f ('t':'|':xs) = Just $ T $ Path xs
-          f ('m':'|':xs) | (xs','|':ys) <- break (== '|') xs = Just $ M (Path xs') (Path ys)
-          f ('W':'|':xs) = Just $ RW $ Path xs
-          f ('R':'|':xs) = Just $ RR $ Path xs
-          f ('D':'|':xs) = Just $ RD $ Path xs
-          f ('Q':'|':xs) = Just $ RQ $ Path xs
-          f ('T':'|':xs) = Just $ RT $ Path xs
-          f ('M':'|':xs) | (xs','|':ys) <- break (== '|') xs = Just $ RM (Path xs') (Path ys)
-          f _ = Nothing
-
-cased :: String -> String
-cased | isWindows = map toLower
-      | otherwise = id
-
-valid :: FilePath -> Access -> Bool
-valid t (R p) = inTmp t p
-valid t (Q p) = inTmp t p
-valid t (W p) | isWindows = inTmp t p
-              | otherwise = not $ "/dev/" `isPrefixOf` unpath p
-valid t (D p) = inTmp t p
-valid t (T p) = inTmp t p
-valid t (M p _) = inTmp t p
-valid _ (RW _) = False -- sort on Windows produces this
-valid _ _ = True
-
-inTmp :: FilePath -> Path -> Bool
-inTmp t = isPrefixOf (cased t) . cased . unpath

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -69,7 +69,7 @@ errorFrom _ = undefined
 
 
 fsatrace :: String -> [String]
-fsatrace flags = [cd </> ".." </> "fsatrace", flags, "-", "--"]
+fsatrace flags = [pwd </> ".." </> "fsatrace", flags, "-", "--"]
 
 parsedOutputFrom :: [String] -> IO (Maybe [Access])
 parsedOutputFrom x = do
@@ -226,9 +226,9 @@ cased :: String -> String
 cased | isWindows = map toLower
       | otherwise = id
 
-cd :: FilePath
-{-# NOINLINE cd #-}
-cd = unsafePerformIO (getCurrentDirectory >>= canonicalizePath)
+pwd :: FilePath
+{-# NOINLINE pwd #-}
+pwd = unsafePerformIO (getCurrentDirectory >>= canonicalizePath)
 
 valid :: FilePath -> Access -> Bool
 valid t (R p) = inTmp t p

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -138,18 +138,3 @@ main = do
             ]
             ++ [qc "cl" $ prop_cl clcsrc (rvalid ncldeps) | hascl]
             ++ [qc "echo" $ prop_echo emitc srcc | sm == Shelled]
-
-
-valid :: FilePath -> Access Path -> Bool
-valid t (R p) = inTmp t p
-valid t (Q p) = inTmp t p
-valid t (W p) | isWindows = inTmp t p
-              | otherwise = not $ "/dev/" `isPrefixOf` unpath p
-valid t (D p) = inTmp t p
-valid t (T p) = inTmp t p
-valid t (M p _) = inTmp t p
-valid _ (RW _) = False -- sort on Windows produces this
-valid _ _ = True
-
-inTmp :: FilePath -> Path -> Bool
-inTmp t = isPrefixOf (cased t) . cased . unpath

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -92,11 +92,11 @@ allTests sp sm = withSystemTempDirectory (if sp == Spaced then "fsatrace with sp
 
   sequence $
     [ noisy "args" >> quickCheckWithResult (stdArgs {maxSuccess=10}) (\x -> runReader (prop_ArgsRoundtrip x) e) -- qc 10 "args" prop_args
-    , qc "cp" $ prop_cp emitc srcc
+    ] ++ gccTests ++
+    [ qc "cp" $ prop_cp emitc srcc
     , qc "touch" $ prop_touch srcc
     , qc "rm" $ prop_rm srcc
     , qc "mv" $ prop_mv emitc srcc
     ]
-    ++ gccTests
     ++ clTests
     ++ [qc "echo" $ prop_echo emitc srcc | sm == Shelled]

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -42,14 +42,14 @@ errorFrom (cmd:args) = do
 errorFrom _ = undefined
 
 
-parsedOutputFrom :: [String] -> IO (Maybe [Access])
+parsedOutputFrom :: [String] -> IO (Maybe [Access Path])
 parsedOutputFrom x = do
   mout <- outputFrom x
   return $ case mout of
-                Just out -> Just $ parseFSATrace out
+                Just out -> Just $ map (fmap Path) $ parseFSATrace out
                 Nothing -> Nothing
 
-yields :: Reader Env [String] -> [Access] -> Prop
+yields :: Reader Env [String] -> [Access Path] -> Prop
 yields eargs res = do
   e <- ask
   return $ monadicIO $ do
@@ -92,10 +92,10 @@ prop_touch dst = command "t" ["touch", unpath dst] `yields` [T dst]
 prop_rm :: Path -> Prop
 prop_rm dst = command "rwmd" ["rm", unpath dst] `yields` [D dst]
 
-prop_gcc :: Path -> [Access] -> Prop
+prop_gcc :: Path -> [Access Path] -> Prop
 prop_gcc src deps = command "r" ["gcc", "-E", unpath src] `yields` deps
 
-prop_cl :: Path -> [Access] -> Prop
+prop_cl :: Path -> [Access Path] -> Prop
 prop_cl src deps = command "r" ["cl", "/nologo", "/E", unpath src] `yields` deps
 
 main :: IO ()
@@ -140,7 +140,7 @@ main = do
             ++ [qc "echo" $ prop_echo emitc srcc | sm == Shelled]
 
 
-valid :: FilePath -> Access -> Bool
+valid :: FilePath -> Access Path -> Bool
 valid t (R p) = inTmp t p
 valid t (Q p) = inTmp t p
 valid t (W p) | isWindows = inTmp t p

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -121,4 +121,4 @@ allTests sp sm = withSystemTempDirectory (if sp == Spaced then "fsatrace with sp
     ++ clTests
     ++ [qc "echo" $ prop_echo emitc srcc | sm == Shelled]
     -- FIXME: Remove the restriction on sm == Unshelled
-    ++ [ noisy "random" >> quickCheckWithResult (stdArgs {maxSuccess=100}) (\x -> runReader (prop_Tester x) e) | sp == Unspaced, sm == Unshelled]
+    ++ [ noisy "random" >> quickCheckWithResult (stdArgs {maxSuccess=100}) (\x -> runReader (prop_Tester x) e) | sp == Unspaced, fixme (sm == Unshelled) True]

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -22,7 +22,7 @@ import           Test.QuickCheck.Monadic
 prop_ArgsRoundtrip :: [Arg] -> Prop
 prop_ArgsRoundtrip args = do
   isShell <- asks shellMode
-  let safe = if isShell == Shelled then filter (`notElem` "\n\r\"%$\\") else id
+  let safe = if isShell == Shelled then filter (`notElem` "\n\r\"%$\\`") else id
   c <- command "x" $ "dumpargs" : map (safe . unarg) args
   return $ monadicIO $ do
     mout <- liftIO $ systemStdout c

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -20,7 +20,6 @@ import           Test.QuickCheck.Monadic
 
 data Env = Env
     { shellMode :: ShellMode
-    , spaceMode :: SpaceMode
     , tmpDir :: FilePath
     }
 
@@ -165,7 +164,7 @@ main = do
               srcc = Path $ tsrc </> "src.c"
               clcsrc = Path $ tsrc </> "win" </> "handle.c"
               rvalid = sort . filter (valid t) . map (R . Path)
-              e = Env {shellMode = sm, spaceMode = sp, tmpDir = t}
+              e = Env {shellMode = sm, tmpDir = t}
               qc s p = noisy s >> quickCheckWithResult (stdArgs {maxSuccess=1}) (runReader p e)
           _ <- outputFrom ["cp", "-R", src, tsrc]
           deps <- outputFrom ["gcc", "-MM", unpath emitc]

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -29,7 +29,7 @@ type Prop = Reader Env Property
 newtype Arg = Arg { unarg :: String } deriving (Show, Eq)
 
 instance Arbitrary Arg where
-  arbitrary = liftM Arg $ listOf1 validChars
+  arbitrary = Arg <$> listOf1 validChars
     where validChars = arbitrary `suchThat` (`notElem` "\0")
 
 newtype Path = Path { unpath :: FilePath }

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -46,7 +46,7 @@ parsedOutputFrom :: [String] -> IO (Maybe [Access])
 parsedOutputFrom x = do
   mout <- outputFrom x
   return $ case mout of
-                Just out -> Just $ parse out
+                Just out -> Just $ parseFSATrace out
                 Nothing -> Nothing
 
 yields :: Reader Env [String] -> [Access] -> Prop
@@ -125,7 +125,7 @@ main = do
               qc s p = noisy s >> quickCheckWithResult (stdArgs {maxSuccess=1}) (runReader p e)
           _ <- outputFrom ["cp", "-R", src, tsrc]
           deps <- outputFrom ["gcc", "-MM", unpath emitc]
-          ndeps <- mapM canonicalizePath (parseDeps deps)
+          ndeps <- mapM canonicalizePath (parseMakefileDeps deps)
           cldeps <- if hascl then errorFrom ["cl", "/nologo", "/showIncludes", "/E", "/DPATH_MAX=4096", unpath clcsrc] else return []
           ncldeps <- if hascl then mapM canonicalizePath (unpath clcsrc : parseClDeps cldeps) else return []
           sequence $

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -152,10 +152,10 @@ prop_cl :: Path -> [Access] -> Prop
 prop_cl src deps = command "r" ["cl", "/nologo", "/E", unpath src] `yields` whenTracing deps
 
 main :: IO ()
-main = sequence [allTests sp sm tm | sp <- allValues, sm <- allValues, tm <- allValues]
-       >>= mapM_ (mapM_ chk)
-  where chk x = unless (isSuccess x) exitFailure
-        noisy s = putStrLn ("Testing " ++ s)
+main = do
+    results <- sequence [allTests sp sm tm | sp <- allValues, sm <- allValues, tm <- allValues]
+    when (any (not . isSuccess) $ concat results) exitFailure
+  where noisy s = putStrLn ("Testing " ++ s)
         banner x = putStrLn $ "================ " ++ x ++ " ================"
         dirname Unspaced = "fsatrace"
         dirname Spaced = "fsatrace with spaces"

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -22,7 +22,7 @@ prop_args :: [Arg] -> Prop
 prop_args args = do
   c <- command "x" $ "dumpargs" : map unarg args
   return $ monadicIO $ do
-    mout <- run $ outputFrom c
+    mout <- run $ systemStdout c
     assert $ case mout of
               Just out -> args == (Arg <$> read (head $ lines out))
               Nothing -> False
@@ -81,8 +81,8 @@ main = do
               rvalid = sort . filter (valid t) . map (R . Path)
               e = Env {shellMode = sm, tmpDir = t, pwdDir = pwd}
               qc s p = noisy s >> quickCheckWithResult (stdArgs {maxSuccess=1}) (runReader p e)
-          _ <- outputFrom ["cp", "-R", src, tsrc]
-          deps <- outputFrom ["gcc", "-MM", unpath emitc]
+          _ <- systemStdout ["cp", "-R", src, tsrc]
+          deps <- systemStdout ["gcc", "-MM", unpath emitc]
           ndeps <- mapM canonicalizePath (parseMakefileDeps deps)
           cldeps <- if hascl then errorFrom ["cl", "/nologo", "/showIncludes", "/E", "/DPATH_MAX=4096", unpath clcsrc] else return []
           ncldeps <- if hascl then mapM canonicalizePath (unpath clcsrc : parseClDeps cldeps) else return []

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -6,6 +6,7 @@ import           Utils
 import           Parse
 
 import           Control.Monad
+import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Reader
 import           Data.List.Extra
 import           Data.Maybe
@@ -22,7 +23,7 @@ prop_args :: [Arg] -> Prop
 prop_args args = do
   c <- command "x" $ "dumpargs" : map unarg args
   return $ monadicIO $ do
-    mout <- run $ systemStdout c
+    mout <- liftIO $ systemStdout c
     assert $ case mout of
               Just out -> args == (Arg <$> read (head $ lines out))
               Nothing -> False

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -34,7 +34,7 @@ prop_ArgsRoundtrip args = do
 prop_Tester :: (FSATest, [Act]) -> Prop
 prop_Tester (p, actLong) = do
   e <- ask
-  act <- return $ limitCmdLine 1500 e actLong
+  act <- return $ limitCmdLine 1500 e $ map (no32to64 p) actLong
   let ans = concatMap (predict e) act
   yieldsPrepare False
       (sequence_ [writeFile x "" | R (Path x) <- ans])

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -10,7 +10,7 @@ import           Data.Maybe
 import           System.Directory
 import           System.Exit
 import           System.FilePath
-import           System.Info
+import           System.Info.Extra
 import           System.IO.Temp
 import           System.IO.Unsafe
 import           System.Process
@@ -43,9 +43,6 @@ instance Show Path where
 instance Ord Path where
   compare (Path x) (Path y) = compare (cased x) (cased y)
 
-
-isWindows :: Bool
-isWindows = os == "mingw32"
 
 prop_args :: [Arg] -> Prop
 prop_args args = do

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -55,15 +55,12 @@ prop_cl src deps = command "r" ["cl", "/nologo", "/E", unpath src] `yields` deps
 
 main :: IO ()
 main = do
-    results <- sequence [allTests sp sm | sp <- allValues, sm <- allValues]
+    results <- sequence [allTests sp sm | sp <- [minBound..], sm <- [minBound..]]
     when (any (not . isSuccess) $ concat results) exitFailure
 
 noisy :: String -> IO ()
 noisy s = putStrLn ("Testing " ++ s)
 
-
-allValues :: (Enum a, Bounded a) => [a]
-allValues = enumFrom minBound
 
 allTests :: SpaceMode -> ShellMode -> IO [Result]
 allTests sp sm = withSystemTempDirectory (if sp == Spaced then "fsatrace with spaces" else "fsatrace") $ \utmp -> do

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -1,6 +1,6 @@
 
 -- | A test of the FSATrace program
-module Main(main) where
+module Test(main) where
 
 import           Control.Monad
 import           Control.Monad.Reader

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -3,7 +3,7 @@
 module Test(main) where
 
 import           Control.Monad
-import           Control.Monad.Reader
+import           Control.Monad.Trans.Reader
 import           Data.List
 import           Data.Char
 import           Data.Maybe

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -18,11 +18,12 @@ import           Test.QuickCheck
 import           Test.QuickCheck.Monadic
 --import           Debug.Trace
 
-data Env = Env { shellMode :: ShellMode
-               , traceMode :: TraceMode
-               , spaceMode :: SpaceMode
-               , tmpDir :: FilePath
-               }
+data Env = Env
+    { shellMode :: ShellMode
+    , traceMode :: TraceMode
+    , spaceMode :: SpaceMode
+    , tmpDir :: FilePath
+    }
 
 type Prop = Reader Env Property
 

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -80,9 +80,6 @@ parsedOutputFrom x = do
                 Just out -> Just $ parse out
                 Nothing -> Nothing
 
-toStandard :: FilePath -> FilePath
-toStandard = if isWindows then map (\x -> if x == '\\' then '/' else x) else id
-
 parseDeps :: Maybe String -> [FilePath]
 parseDeps = filter (/= " ") . map unhack . words . hack . drop 1 . dropWhile (/= ':') . fromMaybe ""
   where hack ('\\':' ':xs) = '^':hack xs
@@ -115,11 +112,6 @@ yields eargs eres = do
 data ShellMode = Unshelled | Shelled deriving (Show, Eq, Enum, Bounded)
 data TraceMode = Untraced | Traced deriving (Show, Eq, Enum, Bounded)
 data SpaceMode = Unspaced | Spaced deriving (Show, Eq, Enum, Bounded)
-
-isShelled :: Reader Env Bool
-isShelled = do
-  sm <- ask
-  return $ shellMode sm == Shelled
 
 
 command :: String -> [String] -> Reader Env [String]

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -1,4 +1,4 @@
-module Main where
+module Main(main) where
 
 import           Control.Monad
 import           Control.Monad.Reader

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -4,7 +4,7 @@ module Test(main) where
 
 import           Control.Monad
 import           Control.Monad.Trans.Reader
-import           Data.List
+import           Data.List.Extra
 import           Data.Char
 import           Data.Maybe
 import           System.Directory
@@ -98,7 +98,7 @@ yields eargs eres = do
     let args = runReader eargs e
         res = runReader eres e
     r <- run $ parsedOutputFrom args
-    let sr | isJust r = Just $ nub $ sort $ filter (valid $ tmpDir e) $ fromJust r
+    let sr | isJust r = Just $ nubSort $ filter (valid $ tmpDir e) $ fromJust r
            | otherwise = Nothing
         ok = sr == Just res
     unless ok $ run $ do

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -1,3 +1,5 @@
+
+-- | A test of the FSATrace program
 module Main(main) where
 
 import           Control.Monad

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -123,29 +123,26 @@ command flags args = do
         quoted ">" = ">"
         quoted x = "\"" ++ x ++ "\""
 
-whenTracing :: [a] -> Reader Env [a]
-whenTracing x = return x
-
 prop_echo :: Path -> Path -> Prop
 prop_echo src dst = command "rwmd" ["echo", unpath src, "|", "sort" , ">", unpath dst] `yields` return [W dst]
 
 prop_cp :: Path -> Path -> Prop
-prop_cp src dst = command "rwmd" ["cp", unpath src, unpath dst] `yields` whenTracing [R src, W dst]
+prop_cp src dst = command "rwmd" ["cp", unpath src, unpath dst] `yields` return [R src, W dst]
 
 prop_mv :: Path -> Path -> Prop
-prop_mv src dst = command "rwmd" ["mv", unpath src, unpath dst] `yields` whenTracing [M dst src]
+prop_mv src dst = command "rwmd" ["mv", unpath src, unpath dst] `yields` return [M dst src]
 
 prop_touch :: Path -> Prop
-prop_touch dst = command "t" ["touch", unpath dst] `yields` whenTracing [T dst]
+prop_touch dst = command "t" ["touch", unpath dst] `yields` return [T dst]
 
 prop_rm :: Path -> Prop
-prop_rm dst = command "rwmd" ["rm", unpath dst] `yields` whenTracing [D dst]
+prop_rm dst = command "rwmd" ["rm", unpath dst] `yields` return [D dst]
 
 prop_gcc :: Path -> [Access] -> Prop
-prop_gcc src deps = command "r" ["gcc", "-E", unpath src] `yields` whenTracing deps
+prop_gcc src deps = command "r" ["gcc", "-E", unpath src] `yields` return deps
 
 prop_cl :: Path -> [Access] -> Prop
-prop_cl src deps = command "r" ["cl", "/nologo", "/E", unpath src] `yields` whenTracing deps
+prop_cl src deps = command "r" ["cl", "/nologo", "/E", unpath src] `yields` return deps
 
 main :: IO ()
 main = do

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -9,6 +9,7 @@ module Utils(
     cased, valid,
     command, yields, yieldsPrepare,
     systemStdout, systemStderr,
+    no32to64,
     fixme
   ) where
 
@@ -172,6 +173,10 @@ showAct e = map f
       ' ' -> "#"
       x   -> [x]
 
+no32to64 :: FSATest -> Act -> Act
+no32to64 FSATest32 (ActE _ xs) = ActE FSATest32 $ map (no32to64 FSATest32) xs
+no32to64 _ (ActE p xs) = ActE p $ map (no32to64 p) xs
+no32to64 _ x = x
 
 -- second value is desirable, first is necessary
 fixme :: a -> a -> a

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -1,0 +1,95 @@
+
+-- | A test of the FSATrace program
+module Utils(
+    Env(..), ShellMode(..), SpaceMode(..),
+    Prop,
+    Path(..), Arg(..),
+    Access(..), parse, valid,
+
+) where
+
+import           Control.Monad.Trans.Reader
+import           Data.List.Extra
+import           Data.Char
+import           Data.Maybe
+import           System.FilePath
+import           System.Info.Extra
+import           Test.QuickCheck
+--import           Debug.Trace
+
+data Env = Env
+    { shellMode :: ShellMode
+    , tmpDir :: FilePath
+    , pwdDir :: FilePath
+    }
+
+type Prop = Reader Env Property
+
+newtype Arg = Arg { unarg :: String } deriving (Show, Eq)
+
+instance Arbitrary Arg where
+  arbitrary = Arg <$> listOf1 validChars
+    where validChars = arbitrary `suchThat` (`notElem` "\0")
+
+newtype Path = Path { unpath :: FilePath }
+
+instance Eq Path where
+  (==) (Path a) (Path b) = equalFilePath a b
+
+instance Show Path where
+  show (Path p) = show p
+
+instance Ord Path where
+  compare (Path x) (Path y) = compare (cased x) (cased y)
+
+
+data ShellMode = Unshelled | Shelled deriving (Show, Eq, Enum, Bounded)
+data SpaceMode = Unspaced | Spaced deriving (Show, Eq, Enum, Bounded)
+
+data Access = R Path
+            | W Path
+            | D Path
+            | Q Path
+            | T Path
+            | M Path Path
+            | RR Path
+            | RW Path
+            | RD Path
+            | RQ Path
+            | RT Path
+            | RM Path Path
+            deriving (Show, Eq, Ord)
+
+parse :: String -> [Access]
+parse = mapMaybe f . lines
+    where f ('w':'|':xs) = Just $ W $ Path xs
+          f ('r':'|':xs) = Just $ R $ Path xs
+          f ('d':'|':xs) = Just $ D $ Path xs
+          f ('q':'|':xs) = Just $ Q $ Path xs
+          f ('t':'|':xs) = Just $ T $ Path xs
+          f ('m':'|':xs) | (xs','|':ys) <- break (== '|') xs = Just $ M (Path xs') (Path ys)
+          f ('W':'|':xs) = Just $ RW $ Path xs
+          f ('R':'|':xs) = Just $ RR $ Path xs
+          f ('D':'|':xs) = Just $ RD $ Path xs
+          f ('Q':'|':xs) = Just $ RQ $ Path xs
+          f ('T':'|':xs) = Just $ RT $ Path xs
+          f ('M':'|':xs) | (xs','|':ys) <- break (== '|') xs = Just $ RM (Path xs') (Path ys)
+          f _ = Nothing
+
+cased :: String -> String
+cased | isWindows = map toLower
+      | otherwise = id
+
+valid :: FilePath -> Access -> Bool
+valid t (R p) = inTmp t p
+valid t (Q p) = inTmp t p
+valid t (W p) | isWindows = inTmp t p
+              | otherwise = not $ "/dev/" `isPrefixOf` unpath p
+valid t (D p) = inTmp t p
+valid t (T p) = inTmp t p
+valid t (M p _) = inTmp t p
+valid _ (RW _) = False -- sort on Windows produces this
+valid _ _ = True
+
+inTmp :: FilePath -> Path -> Bool
+inTmp t = isPrefixOf (cased t) . cased . unpath

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -85,7 +85,7 @@ yields eargs res = do
     let sr | isJust r = Just $ nubSort $ filter (valid $ tmpDir e) $ fromJust r
            | otherwise = Nothing
         ok = sr == Just res
-    unless ok $ run $ do
+    unless ok $ liftIO $ do
       putStrLn $ "Expecting " ++ show res
       putStrLn $ "Got       " ++ show sr
     assert ok

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -4,12 +4,14 @@ module Utils(
     Env(..), ShellMode(..), SpaceMode(..),
     Prop,
     Path(..), Arg(..),
-    cased,
+    cased, valid
 
 ) where
 
+import           Parse
 import           Control.Monad.Trans.Reader
 import           Data.Char
+import           Data.List
 import           System.FilePath
 import           System.Info.Extra
 import           Test.QuickCheck
@@ -47,3 +49,19 @@ data SpaceMode = Unspaced | Spaced deriving (Show, Eq, Enum, Bounded)
 cased :: String -> String
 cased | isWindows = map toLower
       | otherwise = id
+
+
+
+valid :: FilePath -> Access Path -> Bool
+valid t (R p) = inTmp t p
+valid t (Q p) = inTmp t p
+valid t (W p) | isWindows = inTmp t p
+              | otherwise = not $ "/dev/" `isPrefixOf` unpath p
+valid t (D p) = inTmp t p
+valid t (T p) = inTmp t p
+valid t (M p _) = inTmp t p
+valid _ (RW _) = False -- sort on Windows produces this
+valid _ _ = True
+
+inTmp :: FilePath -> Path -> Bool
+inTmp t = isPrefixOf (cased t) . cased . unpath

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -106,12 +106,12 @@ command flags args = do
 
 
 systemStderr :: [String] -> IO (Maybe String)
-systemStderr (cmd:args) = do
-    (res,out,err) <- readProcessWithExitCode cmd args ""
+systemStderr ~(cmd:args) = do
+    (res,_out,err) <- readProcessWithExitCode cmd args ""
     return $ if res == ExitSuccess then Just err else Nothing
 
 systemStdout :: [String] -> IO (Maybe String)
-systemStdout (cmd:args) = do
+systemStdout ~(cmd:args) = do
     (res,out,err) <- readProcessWithExitCode cmd args ""
     when (err /= "") $ hPutStrLn stderr err
     return $ if res == ExitSuccess then Just out else Nothing

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -153,8 +153,7 @@ instance Arbitrary Act where
       [(8, ActR <$> name)
       ,(8, ActW <$> name)
       ,(1, return ActF)
-      -- FIXME: The first 0 should be 1 - at the moment we avoid spawning children
-      ,(if sz > 10 then fixme 0 1 else 0, resize (min 20 $ sz-10) $ ActE <$> arbitrary <*> arbitrary)]
+      ,(if sz > 10 then 1 else 0, resize (min 20 $ sz-10) $ ActE <$> arbitrary <*> arbitrary)]
     where name = vectorOf 2 $ choose ('a', 'z')
 
   shrink (ActE a b) = (flip ActE b <$> (shrink a)) ++ (ActE a <$> shrink b)

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -8,8 +8,9 @@ module Utils(
     Act(..), FSATest, showAct,
     cased, valid,
     command, yields, yieldsPrepare,
-    systemStdout, systemStderr
-) where
+    systemStdout, systemStderr,
+    fixme
+  ) where
 
 import           Parse
 
@@ -138,7 +139,7 @@ instance Show FSATest where
   show FSATest32 = "fsatest32"
 
 instance Arbitrary FSATest where
-  arbitrary = elements [FSATest, FSATest32]
+  arbitrary = elements $ FSATest : [FSATest32 | fixme False True]
   shrink x = [FSATest | x /= FSATest]
 
 data Act = ActR FilePath
@@ -153,7 +154,7 @@ instance Arbitrary Act where
       ,(8, ActW <$> name)
       ,(1, return ActF)
       -- FIXME: The first 0 should be 1 - at the moment we avoid spawning children
-      ,(if sz > 10 then 0 else 0, resize (min 20 $ sz-10) $ ActE <$> arbitrary <*> arbitrary)]
+      ,(if sz > 10 then fixme 0 1 else 0, resize (min 20 $ sz-10) $ ActE <$> arbitrary <*> arbitrary)]
     where name = vectorOf 2 $ choose ('a', 'z')
 
   shrink (ActE a b) = (flip ActE b <$> (shrink a)) ++ (ActE a <$> shrink b)
@@ -171,3 +172,8 @@ showAct e = map f
       '#' -> "##"
       ' ' -> "#"
       x   -> [x]
+
+
+-- second value is desirable, first is necessary
+fixme :: a -> a -> a
+fixme a _ = a

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -5,7 +5,7 @@ module Utils(
     Env(..), ShellMode(..), SpaceMode(..),
     Prop,
     Path(..), Arg(..),
-    Act(..), FSATest, showAct,
+    Act(..), FSATest(..), showAct,
     cased, valid,
     command, yields, yieldsPrepare,
     systemStdout, systemStderr,

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -38,7 +38,8 @@ newtype Arg = Arg { unarg :: String } deriving (Show, Eq)
 
 instance Arbitrary Arg where
   arbitrary = Arg <$> listOf1 validChars
-    where validChars = arbitrary `suchThat` (`notElem` "\0")
+    where validChars = arbitrary `suchThat` \x -> isLatin1 x && x `notElem` "\0>|"
+  shrink (Arg x) = map Arg $ shrink x
 
 newtype Path = Path { unpath :: FilePath }
 

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -156,7 +156,7 @@ instance Arbitrary Act where
       ,(if sz > 10 then 1 else 0, resize (min 20 $ sz-10) $ ActE <$> arbitrary <*> arbitrary)]
     where name = vectorOf 2 $ choose ('a', 'z')
 
-  shrink (ActE a b) = (flip ActE b <$> (shrink a)) ++ (ActE a <$> shrink b)
+  shrink (ActE a b) = (flip ActE b <$> (shrink a)) ++ (ActE a <$> shrink b) ++ b
   shrink _ = []
 
 showAct :: Env -> [Act] -> [String]

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -152,7 +152,7 @@ instance Arbitrary Act where
       [(8, ActR <$> name)
       ,(8, ActW <$> name)
       ,(1, return ActF)
-      -- FIXME: The second 0 should be 1 - at the moment we avoid spawning children
+      -- FIXME: The first 0 should be 1 - at the moment we avoid spawning children
       ,(if sz > 10 then 0 else 0, resize (min 20 $ sz-10) $ ActE <$> arbitrary <*> arbitrary)]
     where name = vectorOf 2 $ choose ('a', 'z')
 

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -122,3 +122,10 @@ systemStdout ~(cmd:args) = do
     (res,out,err) <- readProcessWithExitCode cmd args ""
     when (err /= "") $ hPutStrLn stderr err
     return $ if res == ExitSuccess then Just out else Nothing
+
+systemStdoutPass :: [String] -> IO String
+systemStdoutPass ~(cmd:args) = do
+    (_,out,err) <- readProcessWithExitCode cmd args ""
+    when (err /= "") $ hPutStrLn stderr err
+    return out
+

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -4,14 +4,12 @@ module Utils(
     Env(..), ShellMode(..), SpaceMode(..),
     Prop,
     Path(..), Arg(..),
-    Access(..), parse, valid,
+    cased,
 
 ) where
 
 import           Control.Monad.Trans.Reader
-import           Data.List.Extra
 import           Data.Char
-import           Data.Maybe
 import           System.FilePath
 import           System.Info.Extra
 import           Test.QuickCheck
@@ -46,50 +44,6 @@ instance Ord Path where
 data ShellMode = Unshelled | Shelled deriving (Show, Eq, Enum, Bounded)
 data SpaceMode = Unspaced | Spaced deriving (Show, Eq, Enum, Bounded)
 
-data Access = R Path
-            | W Path
-            | D Path
-            | Q Path
-            | T Path
-            | M Path Path
-            | RR Path
-            | RW Path
-            | RD Path
-            | RQ Path
-            | RT Path
-            | RM Path Path
-            deriving (Show, Eq, Ord)
-
-parse :: String -> [Access]
-parse = mapMaybe f . lines
-    where f ('w':'|':xs) = Just $ W $ Path xs
-          f ('r':'|':xs) = Just $ R $ Path xs
-          f ('d':'|':xs) = Just $ D $ Path xs
-          f ('q':'|':xs) = Just $ Q $ Path xs
-          f ('t':'|':xs) = Just $ T $ Path xs
-          f ('m':'|':xs) | (xs','|':ys) <- break (== '|') xs = Just $ M (Path xs') (Path ys)
-          f ('W':'|':xs) = Just $ RW $ Path xs
-          f ('R':'|':xs) = Just $ RR $ Path xs
-          f ('D':'|':xs) = Just $ RD $ Path xs
-          f ('Q':'|':xs) = Just $ RQ $ Path xs
-          f ('T':'|':xs) = Just $ RT $ Path xs
-          f ('M':'|':xs) | (xs','|':ys) <- break (== '|') xs = Just $ RM (Path xs') (Path ys)
-          f _ = Nothing
-
 cased :: String -> String
 cased | isWindows = map toLower
       | otherwise = id
-
-valid :: FilePath -> Access -> Bool
-valid t (R p) = inTmp t p
-valid t (Q p) = inTmp t p
-valid t (W p) | isWindows = inTmp t p
-              | otherwise = not $ "/dev/" `isPrefixOf` unpath p
-valid t (D p) = inTmp t p
-valid t (T p) = inTmp t p
-valid t (M p _) = inTmp t p
-valid _ (RW _) = False -- sort on Windows produces this
-valid _ _ = True
-
-inTmp :: FilePath -> Path -> Bool
-inTmp t = isPrefixOf (cased t) . cased . unpath

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -154,7 +154,7 @@ instance Arbitrary Act where
       [(8, ActR <$> name)
       ,(8, ActW <$> name)
       ,(1, return ActF)
-      ,(if sz > 10 then 1 else 0, resize (min 20 $ sz-10) $ ActE <$> arbitrary <*> arbitrary)]
+      ,(if sz > 10 then fixme 0 1 else 0, resize (min 20 $ sz-10) $ ActE <$> arbitrary <*> arbitrary)]
     where name = vectorOf 2 $ choose ('a', 'z')
 
   shrink (ActE a b) = (flip ActE b <$> (shrink a)) ++ (ActE a <$> shrink b) ++ b

--- a/test/fsatracetest.cabal
+++ b/test/fsatracetest.cabal
@@ -7,14 +7,14 @@ cabal-version:       >=1.10
 
 executable dumpargs
     main-is: DumpArgs.hs
-    ghc-options: -main-is=DumpArgs.main
+    ghc-options: -main-is DumpArgs.main
     build-depends: base
     hs-source-dirs: .
     default-language:    Haskell2010
 
 test-suite fsatrace-test
     main-is: Test.hs
-    ghc-options: -main-is=Test.main
+    ghc-options: -main-is Test.main
     type: exitcode-stdio-1.0
     ghc-options: -Wall
     build-depends: base
@@ -23,5 +23,6 @@ test-suite fsatrace-test
                   , directory
                   , temporary
                   , process
+                  , mtl
     hs-source-dirs: .
     default-language:    Haskell2010

--- a/test/fsatracetest.cabal
+++ b/test/fsatracetest.cabal
@@ -6,21 +6,22 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 executable dumpargs
-  main-is: DumpArgs.hs
-  build-depends: base
-  hs-source-dirs: .
-  default-language:    Haskell2010
+    main-is: DumpArgs.hs
+    ghc-options: -main-is=DumpArgs.main
+    build-depends: base
+    hs-source-dirs: .
+    default-language:    Haskell2010
 
 test-suite fsatrace-test
-  main-is: Test.hs
-  type: exitcode-stdio-1.0
-  ghc-options: -Wall
-  build-depends: base
-               , QuickCheck
-               , filepath
-               , directory
-               , temporary
-               , process
-               , mtl
-  hs-source-dirs: .
-  default-language:    Haskell2010
+    main-is: Test.hs
+    ghc-options: -main-is=Test.main
+    type: exitcode-stdio-1.0
+    ghc-options: -Wall
+    build-depends: base
+                  , QuickCheck
+                  , filepath
+                  , directory
+                  , temporary
+                  , process
+    hs-source-dirs: .
+    default-language:    Haskell2010

--- a/test/fsatracetest.cabal
+++ b/test/fsatracetest.cabal
@@ -22,6 +22,7 @@ test-suite fsatrace-test
                   , filepath
                   , directory
                   , temporary
+                  , extra
                   , process
                   , mtl
     hs-source-dirs: .

--- a/test/fsatracetest.cabal
+++ b/test/fsatracetest.cabal
@@ -25,6 +25,8 @@ test-suite fsatrace-test
                   , extra
                   , process
                   , transformers
-    other-modules: Utils
+    other-modules:
+        Utils
+        Parse
     hs-source-dirs: .
     default-language:    Haskell2010

--- a/test/fsatracetest.cabal
+++ b/test/fsatracetest.cabal
@@ -24,6 +24,6 @@ test-suite fsatrace-test
                   , temporary
                   , extra
                   , process
-                  , mtl
+                  , transformers
     hs-source-dirs: .
     default-language:    Haskell2010

--- a/test/fsatracetest.cabal
+++ b/test/fsatracetest.cabal
@@ -25,5 +25,6 @@ test-suite fsatrace-test
                   , extra
                   , process
                   , transformers
+    other-modules: Utils
     hs-source-dirs: .
     default-language:    Haskell2010

--- a/test/stack.yaml
+++ b/test/stack.yaml
@@ -1,34 +1,8 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-13.11
+resolver: lts-13.23
+compiler: ghc-8.6.5
 
-compiler: ghc-8.6.3
-
-# Local packages, usually specified by relative directory name
 packages:
 - '.'
-
-# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: []
-
-# Override default flag values for local packages and extra-deps
-flags: {}
-
-# Extra package databases containing global packages
-extra-package-dbs: []
-
-# Control whether we use the GHC we find on the path
-# system-ghc: true
-
-# Require a specific version of stack, using version ranges
-# require-stack-version: -any # Default
-# require-stack-version: >= 0.1.4.0
-
-# Override the architecture used by stack, especially useful on Windows
-# arch: i386
-# arch: x86_64
-
-# Extra directories used by stack for building
-# extra-include-dirs: [/path/to/dir]
-# extra-lib-dirs: [/path/to/dir]

--- a/unix.mk
+++ b/unix.mk
@@ -5,6 +5,9 @@ lib: fsatrace.so
 %.os: %.c
 	$(CC) -c -fPIC $(CPPFLAGS) $(CFLAGS) $< -o $@
 
+fsatest32: fsatest
+	cp $^ $@
+
 fsatrace.so: $(patsubst %.c,%.os,$(SOSRCS))
 	$(CC) -shared $(LFLAGS) $^ -o $@ $(LDLIBS)
 

--- a/win.mk
+++ b/win.mk
@@ -9,11 +9,15 @@ DEPS32=$(patsubst %.o,%.d,$(OBJS32) $(HELPER_OBJ))
 LDLIBS=-lntdll -lpsapi
 
 lib: fsatrace32.dll fsatrace64.dll fsatracehelper.exe
+all: fsatest32.exe
 
 %32.o: %.c
 	$(CC32) -c $(CPPFLAGS32) $(CFLAGS) -march=i686 $< -o $@
 
 fsatracehelper.exe: $(HELPER_OBJ)
+	$(CC32) $< -o $@
+
+fsatest32.exe: src/fsatest32.o
 	$(CC32) $< -o $@
 
 fsatrace64.dll: $(OBJS64)


### PR DESCRIPTION
Since you don't have a Windows machine I thought I'd step up and see what I could do. This patch only changes the test suite, but in a way that when the right things are uncommented it gets to loads of issues.

* I split the Haskell tester into multiple modules
* I added fsatest.c which can be a 32/64 bit binary which takes a command line saying what to do
* Using QuickCheck we can generate random command lines and check we get the right answer

This patch doesn't fix any bugs, but it gives a lot more confidence that any subsequent patches from me are less likely to break stuff.