### PR TITLE
Make sure every process tree is using unique shared memory.

### DIFF
--- a/src/fsatrace.c
+++ b/src/fsatrace.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <windows.h>
 #ifdef _MSC_VER
 #include <io.h>
 #define ssize_t size_t
@@ -103,6 +104,7 @@ main(int argc, char *const argv[])
 	struct shm	shm;
 	size_t		sz = 0;
 	char		envout    [PATH_MAX];
+	char        varout    [PATH_MAX];
 	static char	buf [LOGSZ];
 	char           *const *args = argv + 4;
 	unsigned	nargs = argc - 4;
@@ -121,9 +123,10 @@ main(int argc, char *const argv[])
 		      "   q: dump file stat operations\n"
 		      ,argv[0]);
 	out = argv[2];
-	if ((err = shmInit(&shm, out, LOGSZ, 1)))
+	snprintf(varout, sizeof(varout), "%s_%ld", out, GetTickCount());
+	if ((err = shmInit(&shm, varout, LOGSZ, 1)))
 		fatal("allocating shared memory (%d)", err);
-	snprintf(envout, sizeof(envout), ENVOUT "=%s", out);
+	snprintf(envout, sizeof(envout), ENVOUT "=%s", varout);
 	putenv(envout);
 
 	opts = (const unsigned char *)argv[1];
@@ -163,7 +166,7 @@ main(int argc, char *const argv[])
 		if (rc) {
 			if (verr)
 				aerror(nargs, args, "command failed with code %d", rc);
-		}			
+		}
 		if (strcmp(argv[3], "---")) {
 			uniq(buf, &sz, shm.buf + 4 + 256, "", 0);
 			dump(out, buf, sz);


### PR DESCRIPTION
At the moment if you run `fsatrace rwm - -- some command` twice in parallel then they end up sharing a buffer and results from both get shared. I have solved this in the patch below by making a unique shared memory buffer for each by adding `GetTickCount` into the name. I have marked this PR draft because it only works on Windows, so you will want to do something slightly different.

I couldn't find a good source of unique data in a portable way. The high resolution C time functions are not available on MingW, and the 1 second `time()` is insufficient (both in theory and testing). One option is to make it an `#ifdef`, or maybe you know of a suitable random source.