### PR TITLE
Make injection work more reliably on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ ROOT64=$(LOCALAPPDATA)\Programs\stack\x86_64-windows\ghc-8.6.3\mingw
 ROOT32=$(LOCALAPPDATA)\Programs\stack\i386-windows\ghc-8.6.3\mingw
 CC=$(ROOT64)\bin\gcc
 CC32=$(ROOT32)\bin\gcc
-CPPFLAGS=-D_WIN32_WINNT=0x600 -isystem$(ROOT64)\x86_64-w64-mingw32\include\ddk
-CPPFLAGS32=-D_WIN32_WINNT=0x600 -isystem$(ROOT32)\i686-w64-mingw32\include\ddk
+CPPFLAGS=-D_WIN32_WINNT=0x600 -DIS32=0 -isystem$(ROOT64)\x86_64-w64-mingw32\include\ddk
+CPPFLAGS32=-D_WIN32_WINNT=0x600 -DIS32=1 -isystem$(ROOT32)\i686-w64-mingw32\include\ddk
 OSSRCS=src/win/inject.c src/win/dbg.c
 LDOBJS=$(ROOT64)\x86_64-w64-mingw32\lib\CRT_noglob.o
 INSTALLDIR=$(APPDATA)\local\bin

--- a/src/win/inject.c
+++ b/src/win/inject.c
@@ -49,7 +49,7 @@ void injectProcess(HANDLE proc) {
 		p = strrchr(helper, '\\');
 		memcpy(p+1, helpername, strlen(helpername)+1);
 		injecting = 1;
-		CHK(CreateProcessA(0, helper, 0, 0, 0, 0, "FSATRACEHELPER=1\0", 0, &si, &pi));
+		CHK(CreateProcessA(0, helper, 0, 0, 0, 0, 0, 0, &si, &pi));
 		CHK(WAIT_OBJECT_0 == WaitForSingleObject(pi.hProcess, INFINITE));
 		CHK(GetExitCodeProcess(pi.hProcess, &rc));
 		addr = (FARPROC)(uintptr_t)rc;

--- a/src/win/inject.c
+++ b/src/win/inject.c
@@ -23,7 +23,7 @@ void injectProcess(HANDLE proc) {
 
 	// dll is one of mypath\fsatrace.exe, mypath\fsatrace64.dll or mypath\fsatrace32.dll
 	CHK(IsWow64Process(proc, &is32));
-	if (strcmp(&dll[ndll-4], ".exe") == 0)
+	if (strcasecmp(&dll[ndll-4], ".exe") == 0)
 		ndll -= 4; // .exe
 	else
 		ndll -= 6; // 32.dll or 64.dll


### PR DESCRIPTION
Before 64/64 injection worked well, but nothing else really did. There are two root causes:

* The computed dll name when doing 64 -> 32 was computed as `fsatrace6432.dll` which was no good and didn't inject the hooks properly. I have fixed that up by rewriting the name mapping code.
* The spawning of fsatracehelper was failing because CreateProcess was calling back into inject, so it spawned 100 or so fsatracehelpers and then failed with the injection error from #28. I solve that with a static variable, so once we are actively trying to find out the fsatracehelper output we don't stop injecting. I guess this is a race condition? If so, a mutex could be used to prevent it? Or maybe its not? Certainly the new strategy works in practice.

With that, 64/64, 64/32 and 32/32 all work nicely. The 32/64 doesn't work, but reading https://stackoverflow.com/questions/494284/createremotethread-32-64-and-or-64-32 it doesn't seem it can without some seriously grim assembly. Given its a far less common operation, I'm happy to leave it out for now.