### PR TITLE
Use memfd_create() to create shared memory region on Linux.

### DIFF
--- a/src/unix/shm.c
+++ b/src/unix/shm.c
@@ -25,6 +25,63 @@ hash(unsigned char *str)
 	return h;
 }
 
+#ifdef __linux__
+#include <stdlib.h>
+// On Linux, use memfd_create() to generate the shared memory region.
+// This ensures that is will be properly reclaimed when all references
+// to it are destroyed, unlike /dev/shm segments which persist when
+// the program crashes.
+int
+shmInit(struct shm *shm, const char *key, size_t sz, int root)
+{
+	int	     err = 0;
+	struct priv *p = (struct priv *)shm->storage;
+	if (root) {
+		char *shname = shm->name;
+		assert(key);
+		assert(sizeof(shm->storage) > sizeof(*p));
+		snprintf(shname, sizeof(shm->name), "/fsatrace%ld",
+		    hash((unsigned char *)key));
+		for (size_t i = 0, l = strlen(shname); i < l; i++)
+			if (shname[i] == '/')
+				shname[i] = '_';
+		// IMPORTANT: Do not set MFD_CLOEXEC to ensure the file
+		// descriptor will be copied during exec().
+		err += (-1 == (p->fd = memfd_create(shname, 0))) << 0;
+		err += (root && (-1 == ftruncate(p->fd, sz))) << 1;
+		err += (MAP_FAILED ==
+			   (shm->buf = mmap(0, sz, PROT_READ | PROT_WRITE,
+				MAP_SHARED, p->fd, 0)))
+		    << 2;
+		// Save fd as environment variable to be passed through exec().
+		char fd_val[8];
+		snprintf(fd_val, sizeof(fd_val), "%d", p->fd);
+		err += (-1 == setenv("FSATRACE_SHM_FD", fd_val, 1)) << 3;
+		p->sz = sz;
+	} else {
+		const char *fd_str = getenv("FSATRACE_SHM_FD");
+		assert(fd_str);
+		p->fd = atoi(fd_str);
+		p->sz = sz;
+		err += (MAP_FAILED ==
+			   (shm->buf = mmap(0, sz, PROT_READ | PROT_WRITE,
+				MAP_SHARED, p->fd, 0)))
+		    << 2;
+	}
+	return err;
+}
+
+int
+shmTerm(struct shm *shm, int root)
+{
+	struct priv *p = (struct priv *)shm->storage;
+	int	     err = 0;
+	err += (-1 == munmap(shm->buf, p->sz)) << 0;
+	err += (-1 == close(p->fd)) << 1;
+	return err;
+}
+
+#else // !__linux__
 int
 shmInit(struct shm *shm, const char *key, size_t sz, int root)
 {
@@ -33,7 +90,7 @@ shmInit(struct shm *shm, const char *key, size_t sz, int root)
 	char *	     shname = shm->name;
 	assert(key);
 	assert(sizeof(shm->storage) > sizeof(*p));
-	snprintf(shname, sizeof(shm->storage), "/fsatrace%ld",
+	snprintf(shname, sizeof(shm->name), "/fsatrace%ld",
 	    hash((unsigned char *)key));
 	for (size_t i = 0, l = strlen(shname); i < l; i++)
 		if (shname[i] == '/')
@@ -63,3 +120,4 @@ shmTerm(struct shm *shm, int root)
 	err += (root && (-1 == shm_unlink(shm->name))) << 2;
 	return err;
 }
+#endif // !__linux__


### PR DESCRIPTION
These Linux-specific memory regions are significantly better than
/dev/shm ones since they are automatically reclaimed when all
file descriptors pointing to them are closed. Moreover, they do
not have a real filesystem name, so they cannot conflicts when
multiple commands with the same key are launched.

For context, see this bug entry for the Fuchsia build which is
experiencing fsatrace-related issues:

  https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=95360